### PR TITLE
add docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:apache-buster
+
+RUN apt-get update && \
+    apt-get install -y \
+        libmemcached-dev \
+        zlib1g-dev \
+        unzip \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install mysqli && \
+    pecl install memcache && \
+    docker-php-ext-enable memcache && \
+    a2enmod rewrite
+
+ADD https://getcomposer.org/composer.phar /usr/bin/composer
+
+COPY . /var/www/html/.
+WORKDIR /var/www/html/
+
+RUN chmod +x /usr/bin/composer && \
+    composer install
+
+RUN cd /var/www/html/ && \
+    rm *.sql && \
+    rm *.sh && \
+    cat config/config.php.template config/config.php.docker > config/config.php

--- a/config/config.php.docker
+++ b/config/config.php.docker
@@ -1,0 +1,26 @@
+/**
+ * This configuration file will be appended to
+ * config.php.template when the docker container is started.
+ *
+ * Configuration of the container can be controller by environment variables
+ * - DB_URL: a connection string for the database. ex. mysql://localhost/invoicelion
+ * - ENABLE_DEBUGGER: must be 1 to enable the debugger
+ * - MEMCACHE_SERVERS: a list of memcache servers separate by a comma
+ * - BASE_URL: the URL on which the app is hosted
+ */
+
+class Cache {
+    public static $servers = '127.0.0.1';
+}
+
+DB::$host = parse_url($_ENV['DB_URL'], PHP_URL_HOST) ?: DB::$host;
+DB::$username = parse_url($_ENV['DB_URL'], PHP_URL_USER) ?: DB::$username;
+DB::$password = parse_url($_ENV['DB_URL'], PHP_URL_PASS) ?: DB::$password;
+DB::$database = substr(parse_url($_ENV['DB_URL'], PHP_URL_PATH), 1) ?: DB::$database;
+DB::$port = parse_url($_ENV['DB_URL'], PHP_URL_PORT) ?: DB::$port;
+
+Debugger::$enabled = ($_ENV['ENABLE_DEBUGGER'] ?? 0) == 1;
+
+Cache::$servers = $_ENV['MEMCACHE_SERVERS'] ?? Cache::$servers;
+
+Router::$baseUrl = $_ENV['BASE_URL'] ?? Router::$baseUrl;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.3"
+services:
+  invoicelion:
+    build: .
+    environment:
+      DB_URL: 'mysql://invoice:lion@mysql/invoicelion'
+      MEMCACHE_SERVERS: 'memcache'
+    ports:
+      - "80:80"
+    links:
+      - memcache
+      - mysql
+  memcache:
+    image: memcached:alpine
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_USER: invoice
+      MYSQL_PASSWORD: lion
+      MYSQL_DATABASE: invoicelion
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+    volumes:
+      - './db_structure.sql:/docker-entrypoint-initdb.d/001-structure.sql'


### PR DESCRIPTION
The added files make it trivial to set up a local docker environment for testing.

A local environment can be run simply using `docker-compose up` if both `docker-compose` and `docker` are installed.

I did not manage to get InvoiceLion actually working as I hit https://github.com/Usecue/InvoiceLion/issues/3 as soon as all containers started working.